### PR TITLE
Ensure that deletions work as expected with S3

### DIFF
--- a/app/libs/s3/client.py
+++ b/app/libs/s3/client.py
@@ -43,7 +43,10 @@ class S3Client:
             )
         except ClientError:
             return False
-        return resp.get("DeleteMarker")
+        return (
+            resp.get("ResponseMetadata").get("HTTPStatusCode") == 204
+            or "DeleteMarker" in resp.keys()
+        )
 
     def generate_presigned_download_url(self, file_path: str, expiration: int = 3600):
         """

--- a/app/libs/s3/client.py
+++ b/app/libs/s3/client.py
@@ -11,8 +11,7 @@ class S3Client:
 
     """
 
-    def __init__(self):
-        self.s3 = boto3.resource("s3", region_name=settings.s3_region)
+    s3 = boto3.resource("s3", region_name=settings.s3_region)
 
     def upload(self, path, file_name):
         """


### PR DESCRIPTION
# Changes

- Add new `s3` attribute to the `S3Client` class
- Check whether `ResponseMetadata` or `DeleteMarker` keys are present and return true if they are
- Update tests

Closes #16 